### PR TITLE
CSV extractors

### DIFF
--- a/src/main/java/com/nhl/link/etl/runtime/EtlRuntimeBuilder.java
+++ b/src/main/java/com/nhl/link/etl/runtime/EtlRuntimeBuilder.java
@@ -6,8 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.nhl.link.etl.connect.StreamConnector;
-import com.nhl.link.etl.runtime.connect.URIConnectorFactory;
 import com.nhl.link.etl.runtime.file.csv.CsvExtractorFactory;
 import com.nhl.link.etl.runtime.xml.XmlExtractorFactory;
 import org.apache.cayenne.configuration.server.ServerRuntime;
@@ -79,7 +77,6 @@ public class EtlRuntimeBuilder {
 		extractorFactoryTypes.put(JDBC_EXTRACTOR_TYPE, JdbcExtractorFactory.class);
 		extractorFactoryTypes.put(CSV_EXTRACTOR_TYPE, CsvExtractorFactory.class);
 		extractorFactoryTypes.put(XML_EXTRACTOR_TYPE, XmlExtractorFactory.class);
-		connectorFactoryTypes.put(StreamConnector.class.getName(), URIConnectorFactory.class);
 	}
 
 	/**

--- a/src/test/java/com/nhl/link/etl/unit/EtlIntegrationTest.java
+++ b/src/test/java/com/nhl/link/etl/unit/EtlIntegrationTest.java
@@ -2,6 +2,8 @@ package com.nhl.link.etl.unit;
 
 import static org.junit.Assert.assertEquals;
 
+import com.nhl.link.etl.connect.StreamConnector;
+import com.nhl.link.etl.runtime.connect.URIConnectorFactory;
 import org.junit.After;
 import org.junit.Before;
 
@@ -29,7 +31,9 @@ public abstract class EtlIntegrationTest extends DerbySrcTargetTest {
 
 	protected EtlRuntime createEtl() {
 		Connector c = new DataSourceConnector(srcDataSource);
-		return new EtlRuntimeBuilder().withConnector("derbysrc", c).withTargetRuntime(targetStack.runtime()).build();
+		return new EtlRuntimeBuilder().withConnector("derbysrc", c).withTargetRuntime(targetStack.runtime())
+				.withConnectorFactory(StreamConnector.class, new URIConnectorFactory())
+				.build();
 	}
 
 	protected void assertExec(int extracted, int created, int updated, int deleted, Execution exec) {


### PR DESCRIPTION
Here's a small fix that removes binding of ConnectorFactory<StreamConnector>, which is needed only for tests. Without this fix user will not be able to set custom factory for StreamConnector with EtlRuntimeBuilder.withConnectorFactory(Class<C> connectorType, IConnectorFactory<C> factory) method, because it will be overriden in builder's build() method (from connectorFactoryTypes map).